### PR TITLE
Add graphic and text subheaders

### DIFF
--- a/jbpy/core.py
+++ b/jbpy/core.py
@@ -1061,7 +1061,7 @@ class FileHeader(Group):
             )
         )
         self._append(
-            Field("ENCRYP", "Encryption", 1, BCSN_PI, AnyRange(), Integer, default=0)
+            Field("ENCRYP", "Encryption", 1, BCSN_PI, Constant(0), Integer, default=0)
         )
         self._append(
             Field(
@@ -1577,7 +1577,7 @@ class ImageSubheader(Group):
         )
         self._extend(SecurityFields("Security Fields Image", "I").values())
         self._append(
-            Field("ENCRYP", "Encryption", 1, BCSN_PI, AnyRange(), Integer, default=0)
+            Field("ENCRYP", "Encryption", 1, BCSN_PI, Constant(0), Integer, default=0)
         )
         self._append(
             Field(
@@ -2230,7 +2230,7 @@ class TextSubheader(Group):
         )
         self._extend(SecurityFields("Security Fields Text", "T").values())
         self._append(
-            Field("ENCRYP", "Encryption", 1, BCSN_PI, AnyRange(), Integer, default=0)
+            Field("ENCRYP", "Encryption", 1, BCSN_PI, Constant(0), Integer, default=0)
         )
         self._append(
             Field(
@@ -2251,7 +2251,7 @@ class TextSubheader(Group):
                 BCSN_PI,
                 AnyOf(
                     Constant(0),
-                    MinMax(3, None),  # upper bound in 5.17.2.9 seems like a typo
+                    MinMax(3, 9717),
                 ),
                 Integer,
                 default=0,

--- a/jbpy/core.py
+++ b/jbpy/core.py
@@ -583,6 +583,10 @@ class ComponentCollection(JbpIOComponent):
         field._parent = self
         self._children.append(field)
 
+    def _extend(self, fields: Iterable[JbpIOComponent]) -> None:
+        for field in fields:
+            self._append(field)
+
     def get_offset_of(self, child_obj: JbpIOComponent) -> int:
         offset = self.get_offset()
 
@@ -689,6 +693,203 @@ class SegmentList(ComponentCollection, collections.abc.Sequence):
             self._append(new_field)
         for _ in range(size, len(self._children)):
             self._children.pop()
+
+
+class SecurityFields(Group):
+    """
+    JBP security header/subheader fields
+
+    Args
+    ----
+    name: str
+        Name to give this component
+    x: str
+        Value to replace leading "x" of Short Name in fields
+
+    Note
+    ----
+    See JBP-2024.1 Table 5.10-1 and Table 5.10-2
+
+    """
+
+    def __init__(self, name: str, x: str):
+        super().__init__(name)
+        self._append(
+            Field(
+                f"{x}SCLAS",
+                "Security Classification",
+                1,
+                ECSA,
+                Enum(["T", "S", "C", "R", "U"]),
+                StringISO8859_1,
+                default="U",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCLSY",
+                "Security Classification System",
+                2,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCODE",
+                "Codewords",
+                11,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCTLH",
+                "Control and Handling",
+                2,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SREL",
+                "Releasing Instructions",
+                20,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SDCTP",
+                "Declassification Type",
+                2,
+                ECSA,
+                Enum(["", "DD", "DE", "GD", "GE", "O", "X"]),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SDCDT",
+                "Declassification Date",
+                8,
+                ECSA,
+                AnyOf(Constant(""), DATE_REGEX),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SDCXM",
+                "Declassification Exemption",
+                4,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SDG",
+                "Downgrade",
+                1,
+                ECSA,
+                Enum(["", "S", "C", "R"]),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SDGDT",
+                "Downgrade Date",
+                8,
+                ECSA,
+                AnyOf(Constant(""), DATE_REGEX),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCLTX",
+                "Classification Text",
+                43,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCATP",
+                "Classification Authority Type",
+                1,
+                ECSA,
+                Enum(["", "O", "D", "M"]),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCAUT",
+                "Classification Authority",
+                40,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCRSN",
+                "Classification Reason",
+                1,
+                ECSA,
+                AnyOf(Constant(""), Regex("[A-G]")),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SSRDT",
+                "Security Source Date",
+                8,
+                ECSA,
+                AnyOf(Constant(""), DATE_REGEX),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                f"{x}SCTLN",
+                "Security Control Number",
+                15,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
 
 
 class FileHeader(Group):
@@ -842,182 +1043,7 @@ class FileHeader(Group):
                 default="",
             )
         )
-        self._append(
-            Field(
-                "FSCLAS",
-                "File Security Classification",
-                1,
-                ECSA,
-                Enum(["T", "S", "C", "R", "U"]),
-                StringISO8859_1,
-                default="U",
-            )
-        )
-        self._append(
-            Field(
-                "FSCLSY",
-                "File Security Classification System",
-                2,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCODE",
-                "File Codewords",
-                11,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCTLH",
-                "File Control and Handling",
-                2,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSREL",
-                "File Release Instructions",
-                20,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSDCTP",
-                "File Declassification Type",
-                2,
-                ECSA,
-                Enum(["", "DD", "DE", "GD", "GE", "O", "X"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSDCDT",
-                "File Declassification Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSDCXM",
-                "File Declassification Exemption",
-                4,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSDG",
-                "File Downgrade",
-                1,
-                ECSA,
-                Enum(["", "S", "C", "R"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSDGDT",
-                "File Downgrade Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCLTX",
-                "File Classification Text",
-                43,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCATP",
-                "File Classification Authority Type",
-                1,
-                ECSA,
-                Enum(["", "O", "D", "M"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCAUT",
-                "File Classification Authority",
-                40,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCRSN",
-                "File Classification Reason",
-                1,
-                ECSA,
-                AnyOf(Constant(""), Regex("[A-G]")),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSSRDT",
-                "File Security Source Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "FSCTLN",
-                "File Security Control Number",
-                15,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
+        self._extend(SecurityFields("File Header Security Fields", "F").values())
         self._append(
             Field(
                 "FSCOP", "File Copy Number", 5, BCSN_PI, AnyRange(), Integer, default=0
@@ -1549,182 +1575,7 @@ class ImageSubheader(Group):
                 default="",
             )
         )
-        self._append(
-            Field(
-                "ISCLAS",
-                "Image Security Classification",
-                1,
-                ECSA,
-                Enum(["T", "S", "C", "R", "U"]),
-                StringISO8859_1,
-                default="U",
-            )
-        )
-        self._append(
-            Field(
-                "ISCLSY",
-                "Image Security Classification System",
-                2,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCODE",
-                "Image Codewords",
-                11,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCTLH",
-                "Image Control and Handling",
-                2,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISREL",
-                "Image Release Instructions",
-                20,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISDCTP",
-                "Image Declassification Type",
-                2,
-                ECSA,
-                Enum(["", "DD", "DE", "GD", "GE", "O", "X"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISDCDT",
-                "Image Declassification Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISDCXM",
-                "Image Declassification Exemption",
-                4,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISDG",
-                "Image Downgrade",
-                1,
-                ECSA,
-                Enum(["", "S", "C", "R"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISDGDT",
-                "Image Downgrade Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCLTX",
-                "Image Classification Text",
-                43,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCATP",
-                "Image Classification Authority Type",
-                1,
-                ECSA,
-                Enum(["", "O", "D", "M"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCAUT",
-                "Image Classification Authority",
-                40,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCRSN",
-                "Image Classification Reason",
-                1,
-                ECSA,
-                AnyOf(Constant(""), Regex("[A-G]")),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISSRDT",
-                "Image Security Source Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "ISCTLN",
-                "Image Security Control Number",
-                15,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
+        self._extend(SecurityFields("Security Fields Image", "I").values())
         self._append(
             Field("ENCRYP", "Encryption", 1, BCSN_PI, AnyRange(), Integer, default=0)
         )
@@ -2304,20 +2155,138 @@ class GraphicSegment(Group):
         super().print()
 
 
-class TextSegment(Group):
-    def __init__(self, name: str, subheader_size: int, data_size: int):
+class TextSubheader(Group):
+    """
+    Text Subheader fields
+
+    Args
+    ----
+    name: str
+        Name to give this component
+
+    Note
+    ----
+    See JBP-2024.1 Table 5.17-1
+
+    """
+
+    def __init__(self, name: str):
         super().__init__(name)
+
         self._append(
             Field(
-                "subheader",
-                "Placeholder",
-                subheader_size,
-                None,
-                AnyRange(),
-                Bytes,
-                default=b"",
+                "TE",
+                "File Part Type",
+                2,
+                BCSA,
+                Constant("TE"),
+                StringAscii,
+                default="TE",
             )
         )
+        self._append(
+            Field(
+                "TEXTID",
+                "Text Identifier",
+                7,
+                BCSA,
+                AnyRange(),
+                StringAscii,
+                default="",
+            )
+        )
+        self._append(
+            Field(
+                "TXTALVL",
+                "Text Attachment Level",
+                3,
+                BCSN_PI,
+                MinMax(0, 998),
+                Integer,
+                default=0,
+            )
+        )
+        self._append(
+            Field(
+                "TXTDT",
+                "Text Date and Time",
+                14,
+                BCSN,
+                DATETIME_REGEX,
+                StringAscii,
+                default="-" * 14,
+            )
+        )
+        self._append(
+            Field(
+                "TXTITL",
+                "Text Title",
+                80,
+                ECSA,
+                AnyRange(),
+                StringISO8859_1,
+                default="",
+            )
+        )
+        self._extend(SecurityFields("Security Fields Text", "T").values())
+        self._append(
+            Field("ENCRYP", "Encryption", 1, BCSN_PI, AnyRange(), Integer, default=0)
+        )
+        self._append(
+            Field(
+                "TXTFMT",
+                "Text Format",
+                3,
+                BCSA,
+                Enum(["MTF", "STA", "UTI", "U8S"]),
+                StringAscii,
+                default="",  # unclear if this should have a default; there is not one in the doc, but not having a valid default spits out warnings
+            )
+        )
+        self._append(
+            Field(
+                "TXSHDL",
+                "Text Extended Subheader Data Length",
+                5,
+                BCSN_PI,
+                AnyOf(
+                    Constant(0),
+                    MinMax(3, None),  # upper bound in 5.17.2.9 seems like a typo
+                ),
+                Integer,
+                default=0,
+                setter_callback=self._txshdl_handler,
+            )
+        )
+
+    def _txshdl_handler(self, field: Field) -> None:
+        self._remove_all("TXSOFL")
+        self._remove_all("TXSHD")
+        if field.value > 0:
+            after = self._insert_after(
+                field,
+                Field(
+                    "TXSOFL",
+                    "Text Extended Subheader Overflow",
+                    3,
+                    BCSN_PI,
+                    AnyRange(),
+                    Integer,
+                    default=0,
+                ),
+            )
+        if field.value > 3:
+            after = self._insert_after(after, TreSequence("TXSHD", field.value - 3))
+
+    def finalize(self) -> None:
+        super().finalize()
+        _update_tre_lengths(self, "TXSHDL", "TXSOFL", "TXSHD")
+
+
+class TextSegment(Group):
+    def __init__(self, name: str, data_size: int):
+        super().__init__(name)
+        self._append(TextSubheader("subheader"))
         self._append(BinaryPlaceholder("Data", data_size))
 
     def print(self) -> None:
@@ -2383,182 +2352,7 @@ class DataExtensionSubheader(Group):
                 default=1,
             )
         )
-        self._append(
-            Field(
-                "DESCLAS",
-                "DES Security Classification",
-                1,
-                ECSA,
-                Enum(["T", "S", "C", "R", "U"]),
-                StringISO8859_1,
-                default="U",
-            )
-        )
-        self._append(
-            Field(
-                "DESCLSY",
-                "DES Security Classification System",
-                2,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCODE",
-                "DES Codewords",
-                11,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCTLH",
-                "DES Control and Handling",
-                2,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESREL",
-                "DES Release Instructions",
-                20,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESDCTP",
-                "DES Declassification Type",
-                2,
-                ECSA,
-                Enum(["", "DD", "DE", "GD", "GE", "O", "X"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESDCDT",
-                "DES Declassification Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESDCXM",
-                "DES Declassification Exemption",
-                4,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESDG",
-                "DES Downgrade",
-                1,
-                ECSA,
-                Enum(["", "S", "C", "R"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESDGDT",
-                "DES Downgrade Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCLTX",
-                "DES Classification Text",
-                43,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCATP",
-                "DES Classification Authority Type",
-                1,
-                ECSA,
-                Enum(["", "O", "D", "M"]),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCAUT",
-                "DES Classification Authority",
-                40,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCRSN",
-                "DES Classification Reason",
-                1,
-                ECSA,
-                AnyOf(Constant(""), Regex("[A-G]")),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESSRDT",
-                "DES Security Source Date",
-                8,
-                ECSA,
-                AnyOf(Constant(""), DATE_REGEX),
-                StringISO8859_1,
-                default="",
-            )
-        )
-        self._append(
-            Field(
-                "DESCTLN",
-                "DES Security Control Number",
-                15,
-                ECSA,
-                AnyRange(),
-                StringISO8859_1,
-                default="",
-            )
-        )
+        self._extend(SecurityFields("Security Fields DES", "DE").values())
         # DESOFLW
         # DESITEM
         self._append(
@@ -2836,7 +2630,7 @@ class Jbp(Group):
         self._append(
             SegmentList(
                 "TextSegments",
-                lambda n: TextSegment(n, None, None),
+                lambda n: TextSegment(n, None),
                 maximum=999,
             )
         )

--- a/jbpy/core.py
+++ b/jbpy/core.py
@@ -425,7 +425,7 @@ class Field(JbpIOComponent):
         self._converter = converter_class(name, size)
         self._setter_callback = setter_callback
 
-        self.encoded_value = self._converter.to_bytes(default)
+        self._encoded_value = self._converter.to_bytes(default)
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
@@ -2240,7 +2240,7 @@ class TextSubheader(Group):
                 BCSA,
                 Enum(["MTF", "STA", "UTI", "U8S"]),
                 StringAscii,
-                default="",  # unclear if this should have a default; there is not one in the doc, but not having a valid default spits out warnings
+                default="",
             )
         )
         self._append(

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -462,6 +462,7 @@ def test_field(caplog):
 
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="jbpy.core"):
+        # "invalid" default does not result in a warning
         jbpy.core.Field(
             "MyField",
             "Description",
@@ -471,8 +472,7 @@ def test_field(caplog):
             jbpy.core.StringUtf8,
             default="abc",
         )
-        assert len(caplog.records) == 1
-        assert "Invalid" in caplog.records[0].message
+        assert not caplog.records
 
 
 def test_binaryplaceholder():

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -344,7 +344,7 @@ def test_imseg():
     subheader["UDIDL"].value = 100
     assert "UDOFL" in subheader
     assert "UDID" in subheader
-    len(subheader["UDID"]) == 0  # NO TREs
+    assert len(subheader["UDID"]) == 0  # NO TREs
 
     assert "IXSOFL" not in subheader
     assert "IXSHD" not in subheader
@@ -579,3 +579,32 @@ def test_txtseg():
     subheader["TXSHDL"].value = 100
     assert "TXSOFL" in subheader
     assert "TXSHD" in subheader
+
+
+def add_graphicseg(ntf):
+    ntf["FileHeader"]["NUMS"].value += 1
+    idx = ntf["FileHeader"]["NUMS"].value - 1
+    ntf["GraphicSegments"][idx]["subheader"]["SID"].value = "Unit Test"
+    ntf["GraphicSegments"][idx]["subheader"]["SNAME"].value = "S is for graphic"
+    ntf["GraphicSegments"][idx]["subheader"]["SSCLAS"].value = "U"
+    ntf["GraphicSegments"][idx]["subheader"]["SLOC"].value = (0, 1)
+    ntf["GraphicSegments"][idx]["subheader"]["SBND1"].value = (2, 3)
+    ntf["GraphicSegments"][idx]["subheader"]["SBND2"].value = (4, 5)
+    ntf["GraphicSegments"][idx]["Data"].size = 20 * 30
+    return ntf
+
+
+def test_graphicseg():
+    ntf = emtpy_nitf()
+    add_graphicseg(ntf)
+    check_roundtrip(ntf)
+    add_graphicseg(ntf)
+    assert ntf["FileHeader"]["NUMS"].value == 2
+    check_roundtrip(ntf)
+    subheader = ntf["GraphicSegments"][0]["subheader"]
+
+    assert "SXSOFL" not in subheader
+    assert "SXSHD" not in subheader
+    subheader["SXSHDL"].value = 100
+    assert "SXSOFL" in subheader
+    assert "SXSHD" in subheader

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -548,3 +548,34 @@ def test_unknown_tre():
     unk["TREDATA"].size = 456
     unk.finalize()
     assert unk["TREL"].value == 456
+
+
+def add_txtseg(ntf):
+    ntf["FileHeader"]["NUMT"].value += 1
+    idx = ntf["FileHeader"]["NUMT"].value - 1
+    ntf["TextSegments"][idx]["subheader"]["TEXTID"].value = "Unit Te"
+    ntf["TextSegments"][idx]["subheader"]["TXTALVL"].value = 24
+    ntf["TextSegments"][idx]["subheader"]["TXTDT"].value = datetime.datetime(
+        1955, 11, 5
+    ).strftime("%Y%m%d%H%M%S")
+    ntf["TextSegments"][idx]["subheader"]["TXTITL"].value = "the text title"
+    ntf["TextSegments"][idx]["subheader"]["TSCLAS"].value = "U"
+    ntf["TextSegments"][idx]["subheader"]["TXTFMT"].value = "U8S"
+    ntf["TextSegments"][idx]["Data"].size = 20 * 30
+    return ntf
+
+
+def test_txtseg():
+    ntf = emtpy_nitf()
+    add_txtseg(ntf)
+    check_roundtrip(ntf)
+    add_txtseg(ntf)
+    assert ntf["FileHeader"]["NUMT"].value == 2
+    check_roundtrip(ntf)
+    subheader = ntf["TextSegments"][0]["subheader"]
+
+    assert "TXSOFL" not in subheader
+    assert "TXSHD" not in subheader
+    subheader["TXSHDL"].value = 100
+    assert "TXSOFL" in subheader
+    assert "TXSHD" in subheader


### PR DESCRIPTION
# Description
This PR replaces the placeholder Text and Graphic subheaders with full implementations.

## Notes
- factor out `SecurityFields` to a separate group
  - use new `_extend` method to add `SecurityFields` in an API compatible way to all the places I factored out
- change range of all `ENCRYP` fields to `Constant(0)` to better match document
- `Field.__init__()` now sets `self._encoded_value` (with the underscore) rather than `self.encoded_value` to avoid range checking on defaults

# Demo
<details><summary>jbpinfo with one of the JITC test NITFs containing a text segment</summary>

```
pdm run jbpinfo /host_shared/JITC_QuickLook_NITF/Quick-Look-Set-v2023.11.30/2.\ Data\ Segments/Test\ Files/NITF_TXT_POS_01.ntf 
TXTFMT: Invalid field value: b'   '
TREL: Invalid field value: b'00000'
TREL: Invalid field value: b'00000'
TREL: Invalid field value: b'00000'
FHDR                     4 @           0 b'NITF'
FVER                     5 @           4 b'02.10'
CLEVEL                   2 @           9 b'03'
STYPE                    4 @          11 b'BF01'
OSTAID                  10 @          15 b'JITC-01   '
FDT                     14 @          25 b'20150330194538'
FTITLE                  80 @          39 b'0016-SingleBlocked-RPC-PIAPRD-Text                                              '
FSCLAS                   1 @         119 b'U'
FSCLSY                   2 @         120 b'US'
FSCODE                  11 @         122 b'           '
FSCTLH                   2 @         133 b'  '
FSREL                   20 @         135 b'                    '
FSDCTP                   2 @         155 b'  '
FSDCDT                   8 @         157 b'        '
FSDCXM                   4 @         165 b'    '
FSDG                     1 @         169 b' '
FSDGDT                   8 @         170 b'        '
FSCLTX                  43 @         178 b'                                           '
FSCATP                   1 @         221 b' '
FSCAUT                  40 @         222 b'                                        '
FSCRSN                   1 @         262 b' '
FSSRDT                   8 @         263 b'        '
FSCTLN                  15 @         271 b'               '
FSCOP                    5 @         286 b'00000'
FSCPYS                   5 @         291 b'00000'
ENCRYP                   1 @         296 b'0'
FBKGC                    3 @         297 b'\x00~\x00'
ONAME                   24 @         300 b'NITFS CTE Facility      '
OPHONE                  18 @         324 b'(520) 538-5458    '
FL                      12 @         342 b'000000035217'
HL                       6 @         354 b'000883'
NUMI                     3 @         360 b'001'
LISH001                  6 @         363 b'001733'
LI001                   10 @         369 b'0000032300'
NUMS                     3 @         379 b'000'
NUMX                     3 @         382 b'000'
NUMT                     3 @         385 b'001'
LTSH001                  4 @         388 b'0282'
LT001                    5 @         392 b'00019'
NUMDES                   3 @         397 b'000'
NUMRES                   3 @         400 b'000'
UDHDL                    5 @         403 b'00000'
XHDL                     5 @         408 b'00470'
XHDLOFL                  3 @         413 b'000'
TRETAG                   6 @         416 b'PIAPRD'
TREL                     5 @         422 b'00456'
TREDATA                456 @         427 b'0016-SingleBlocked-RPC-PIAPRD-Text                                                              E        00000000000000000016JITC-00016  20150330194538                                        000001Fuel Storage                                                                                               
                                                                                                                                                    0000'                                                                                                                                                                                                  # ImageSegment 1
IM                       2 @         883 b'IM'
IID1                    10 @         885 b'IM-10     '
IDATIM                  14 @         895 b'20141103074800'
TGTID                   17 @         909 b'                 '
IID2                    80 @         926 b'20141103074800-0016-SingleBlocked-RPC-PIAPRD-Text                               '
ISCLAS                   1 @        1006 b'U'
ISCLSY                   2 @        1007 b'US'
ISCODE                  11 @        1009 b'           '
ISCTLH                   2 @        1020 b'  '
ISREL                   20 @        1022 b'                    '
ISDCTP                   2 @        1042 b'  '
ISDCDT                   8 @        1044 b'        '
ISDCXM                   4 @        1052 b'    '
ISDG                     1 @        1056 b' '
ISDGDT                   8 @        1057 b'        '
ISCLTX                  43 @        1065 b'                                           '
ISCATP                   1 @        1108 b' '
ISCAUT                  40 @        1109 b'                                        '
ISCRSN                   1 @        1149 b' '
ISSRDT                   8 @        1150 b'        '
ISCTLN                  15 @        1158 b'               '
ENCRYP                   1 @        1173 b'0'
ISORCE                  42 @        1174 b'                                          '
NROWS                    8 @        1216 b'00000512'
NCOLS                    8 @        1224 b'00000512'
PVTYPE                   3 @        1232 b'INT'
IREP                     8 @        1235 b'MONO    '
ICAT                     8 @        1243 b'VIS     '
ABPP                     2 @        1251 b'11'
PJUST                    1 @        1253 b'R'
ICORDS                   1 @        1254 b' '
NICOM                    1 @        1255 b'0'
IC                       2 @        1256 b'C3'
COMRAT                   4 @        1258 b'00.0'
NBANDS                   1 @        1262 b'1'
IREPBAND00001            2 @        1263 b'M '
ISUBCAT00001             6 @        1265 b'      '
IFC00001                 1 @        1271 b'N'
IMFLT00001               3 @        1272 b'   '
NLUTS00001               1 @        1275 b'0'
ISYNC                    1 @        1276 b'0'
IMODE                    1 @        1277 b'B'
NBPR                     4 @        1278 b'0001'
NBPC                     4 @        1282 b'0001'
NPPBH                    4 @        1286 b'0512'
NPPBV                    4 @        1290 b'0512'
NBPP                     2 @        1294 b'12'
IDLVL                    3 @        1296 b'001'
IALVL                    3 @        1299 b'000'
ILOC                    10 @        1302 b'0000000000'
IMAG                     4 @        1312 b'1.0 '
UDIDL                    5 @        1316 b'00000'
IXSHDL                   5 @        1321 b'01290'
IXSOFL                   3 @        1326 b'000'
TRETAG                   6 @        1329 b'RPC00B'
TREL                     5 @        1335 b'01041'
TREDATA               1041 @        1340 b'10024.300000.1501072009893-20.3566+118.6194+000401154009958+00.0483+000.0445+0501+2.986720E-4-1.608556E-8-9.300977E-1+7.151000E-2+5.932331E-7+1.679286E-5-2.073496E-4-1.383904E-8-1.459264E-4+1.018601E-5-2.375199E-8+0.000000E+0+0.000000E+0+1.849785E-8+5.406193E-7-5.645313E-8-3.897124E-7+1.865093E-5+2.2640
24E-6+2.091867E-8+1.000000E+0-6.551228E-7+1.568948E-4-2.149083E-4+0.000000E+0-2.266145E-8-1.425920E-6-5.735480E-7+5.955617E-8+1.013105E-7-2.217184E-8+0.000000E+0+2.375838E-8+0.000000E+0-2.328948E-8+0.000000E+0+2.051750E-8-1.724055E-8-8.947411E-8-2.024972E-8-1.196460E-3+9.930582E-1+1.108027E-7+7.128413E-3+3.228264E-7+3.907465E-4-8.861660E-5+5.926676E-4+0.000000E+0+8.743840E-6-3.392678E-7+3.527134E-7-1.125689E-8+1.242165E-7+0.000000E+0+0.000000E+0-4.900260E-8-3.114450E-6-1.388687E-7+0.000000E+0+1.000000E+0+5.968298E-4+3.020886E-7-3.795665E-4+0.000000E+0+1.009934E-6+1.657396E-7+3.558221E-7+0.000000E+0-1.362394E-7+2.438739E-8-1.363230E-8+0.000000E+0-1.422392E-8+2.702465E-8+0.000000E+0+1.053448E-8+0.000000E+0+1.162279E-8+1.171241E-8'                                                                                                                                                                                                                                                                                                               TRETAG                   6 @        2381 b'ICHIPB'
TREL                     5 @        2387 b'00224'
TREDATA                224 @        2392 b'000001.00000000000000000.50000000000.50000000000.50000000511.50000000511.50000000000.50000000511.50000000511.50000008199.74100010036.69400008241.88000009527.43500007690.48200009994.55600007732.62000009485.2960002143100019772'
Data                 32300 @        2616 <Binary>
# TextSegment 1
TE                       2 @       34916 b'TE'
TEXTID                   7 @       34918 b'JITC001'
TXTALVL                  3 @       34925 b'000'
TXTDT                   14 @       34928 b'20141103074800'
TXTITL                  80 @       34942 b'0016-SingleBlocked-RPC-PIAPRD-Text                                              '
TSCLAS                   1 @       35022 b'U'
TSCLSY                   2 @       35023 b'US'
TSCODE                  11 @       35025 b'           '
TSCTLH                   2 @       35036 b'  '
TSREL                   20 @       35038 b'                    '
TSDCTP                   2 @       35058 b'  '
TSDCDT                   8 @       35060 b'        '
TSDCXM                   4 @       35068 b'    '
TSDG                     1 @       35072 b' '
TSDGDT                   8 @       35073 b'        '
TSCLTX                  43 @       35081 b'                                           '
TSCATP                   1 @       35124 b' '
TSCAUT                  40 @       35125 b'                                        '
TSCRSN                   1 @       35165 b' '
TSSRDT                   8 @       35166 b'        '
TSCTLN                  15 @       35174 b'               '
ENCRYP                   1 @       35189 b'0'
TXTFMT                   3 @       35190 b'STA'
TXSHDL                   5 @       35193 b'00000'
Data                    19 @       35198 <Binary>

```

</details>

<details><summary>jbpinfo with a JITC file</summary>

```
pdm run jbpinfo /host_shared/JITC_QuickLook_NITF/Quick-Look-Set-v2023.11.30/2.\ Data\ Segments/Test\ Files/NITF_SYM_POS_01.ntf 
SCOLOR: Invalid field value: b' '
TREL: Invalid field value: b'00000'
TREL: Invalid field value: b'00000'
TREL: Invalid field value: b'00000'
FHDR                     4 @           0 b'NITF'
FVER                     5 @           4 b'02.10'
CLEVEL                   2 @           9 b'03'
STYPE                    4 @          11 b'BF01'
OSTAID                  10 @          15 b'JITC-01   '
FDT                     14 @          25 b'20150330194538'
FTITLE                  80 @          39 b'0011-Small-SingleBlocked-IGEOLO-RPC-PIAPRD-CGM                                  '
FSCLAS                   1 @         119 b'U'
FSCLSY                   2 @         120 b'US'
FSCODE                  11 @         122 b'           '
FSCTLH                   2 @         133 b'  '
FSREL                   20 @         135 b'                    '
FSDCTP                   2 @         155 b'  '
FSDCDT                   8 @         157 b'        '
FSDCXM                   4 @         165 b'    '
FSDG                     1 @         169 b' '
FSDGDT                   8 @         170 b'        '
FSCLTX                  43 @         178 b'                                           '
FSCATP                   1 @         221 b' '
FSCAUT                  40 @         222 b'                                        '
FSCRSN                   1 @         262 b' '
FSSRDT                   8 @         263 b'        '
FSCTLN                  15 @         271 b'               '
FSCOP                    5 @         286 b'00000'
FSCPYS                   5 @         291 b'00000'
ENCRYP                   1 @         296 b'0'
FBKGC                    3 @         297 b'\x00\x7f\x00'
ONAME                   24 @         300 b'NITFS CTE Facility      '
OPHONE                  18 @         324 b'(520) 538-5458    '
FL                      12 @         342 b'000000265600'
HL                       6 @         354 b'000629'
NUMI                     3 @         360 b'001'
LISH001                  6 @         363 b'001789'
LI001                   10 @         369 b'0000262144'
NUMS                     3 @         379 b'001'
LSSH001                  4 @         382 b'0258'
LS001                    6 @         386 b'000780'
NUMX                     3 @         392 b'000'
NUMT                     3 @         395 b'000'
NUMDES                   3 @         398 b'000'
NUMRES                   3 @         401 b'000'
UDHDL                    5 @         404 b'00000'
XHDL                     5 @         409 b'00215'
XHDLOFL                  3 @         414 b'000'
TRETAG                   6 @         417 b'PIAPRD'
TREL                     5 @         423 b'00201'
TREDATA                201 @         428 b'0011-Small-SingleBlocked-IGEOLO-RPC-PIAPRD-CGM                                                  E        00000000000000000011JITC-00011  20150330194538                                        0000000000'
# ImageSegment 1
IM                       2 @         629 b'IM'
IID1                    10 @         631 b'IM-01     '
IDATIM                  14 @         641 b'20141103074800'
TGTID                   17 @         655 b'                 '
IID2                    80 @         672 b'20141103074800-0011-Small-SingleBlocked-IGEOLO-RPC-PIAPRD-CGM                   '
ISCLAS                   1 @         752 b'U'
ISCLSY                   2 @         753 b'US'
ISCODE                  11 @         755 b'           '
ISCTLH                   2 @         766 b'  '
ISREL                   20 @         768 b'                    '
ISDCTP                   2 @         788 b'  '
ISDCDT                   8 @         790 b'        '
ISDCXM                   4 @         798 b'    '
ISDG                     1 @         802 b' '
ISDGDT                   8 @         803 b'        '
ISCLTX                  43 @         811 b'                                           '
ISCATP                   1 @         854 b' '
ISCAUT                  40 @         855 b'                                        '
ISCRSN                   1 @         895 b' '
ISSRDT                   8 @         896 b'        '
ISCTLN                  15 @         904 b'               '
ENCRYP                   1 @         919 b'0'
ISORCE                  42 @         920 b'                                          '
NROWS                    8 @         962 b'00000512'
NCOLS                    8 @         970 b'00000512'
PVTYPE                   3 @         978 b'INT'
IREP                     8 @         981 b'MONO    '
ICAT                     8 @         989 b'VIS     '
ABPP                     2 @         997 b'08'
PJUST                    1 @         999 b'R'
ICORDS                   1 @        1000 b'D'
IGEOLO                  60 @        1001 b'+33.365+044.351+33.365+044.354+33.362+044.354+33.362+044.351'
NICOM                    1 @        1061 b'0'
IC                       2 @        1062 b'NC'
NBANDS                   1 @        1064 b'1'
IREPBAND00001            2 @        1065 b'M '
ISUBCAT00001             6 @        1067 b'      '
IFC00001                 1 @        1073 b'N'
IMFLT00001               3 @        1074 b'   '
NLUTS00001               1 @        1077 b'0'
ISYNC                    1 @        1078 b'0'
IMODE                    1 @        1079 b'B'
NBPR                     4 @        1080 b'0001'
NBPC                     4 @        1084 b'0001'
NPPBH                    4 @        1088 b'0512'
NPPBV                    4 @        1092 b'0512'
NBPP                     2 @        1096 b'08'
IDLVL                    3 @        1098 b'001'
IALVL                    3 @        1101 b'000'
ILOC                    10 @        1104 b'0000000000'
IMAG                     4 @        1114 b'1.0 '
UDIDL                    5 @        1118 b'00000'
IXSHDL                   5 @        1123 b'01290'
IXSOFL                   3 @        1128 b'000'
TRETAG                   6 @        1131 b'RPC00B'
TREL                     5 @        1137 b'01041'
TREDATA               1041 @        1142 b'10017.970000.1401323014448+33.3717+044.3517+003101323014448+00.0834+000.0911+0500+0.107799E-2+0.000000E+0-0.100061E+1+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0-0.539327E-3+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0-0.
290697E-6+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.100000E+1+0.000000E+0+0.538998E-3+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.290519E-6+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0-0.285094E-3+0.100085E+1+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.142668E-3+0.000000E+0+0.000000E+0+0.000000E+0+0.203371E-7+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.100000E+1+0.142547E-3+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.203196E-7+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0+0.000000E+0'                                                                                                                                               TRETAG                   6 @        2183 b'ICHIPB'
TREL                     5 @        2189 b'00224'
TREDATA                224 @        2194 b'000001.00000000000000000.50000000000.50000000000.50000000511.50000000511.50000000000.50000000511.50000000511.50000014336.50000014336.50000014336.50000014847.50000014847.50000014336.50000014847.50000014847.5000002646400028900'
Data                262144 @        2418 <Binary>
# GraphicSegment 1
SY                       2 @      264562 b'SY'
SID                     10 @      264564 b'0000000001'
SNAME                   20 @      264574 b'CGM TEST 01         '
SSCLAS                   1 @      264594 b'U'
SSCLSY                   2 @      264595 b'US'
SSCODE                  11 @      264597 b'           '
SSCTLH                   2 @      264608 b'  '
SSREL                   20 @      264610 b'                    '
SSDCTP                   2 @      264630 b'  '
SSDCDT                   8 @      264632 b'        '
SSDCXM                   4 @      264640 b'    '
SSDG                     1 @      264644 b' '
SSDGDT                   8 @      264645 b'        '
SSCLTX                  43 @      264653 b'                                           '
SSCATP                   1 @      264696 b' '
SSCAUT                  40 @      264697 b'                                        '
SSCRSN                   1 @      264737 b' '
SSSRDT                   8 @      264738 b'        '
SSCTLN                  15 @      264746 b'               '
ENCRYP                   1 @      264761 b'0'
SFMT                     1 @      264762 b'C'
SSTRUCT                 13 @      264763 b'0000000000000'
SDLVL                    3 @      264776 b'002'
SALVL                    3 @      264779 b'001'
SLOC                    10 @      264782 b'0000000000'
SBND1                   10 @      264792 b'0002500025'
SCOLOR                   1 @      264802 b'C'
SBND2                   10 @      264803 b'0007900430'
SRES2                    2 @      264813 b'00'
SXSHDL                   5 @      264815 b'00000'
Data                   780 @      264820 <Binary>

```

</details>

# Test

<details><summary>unittests with JITC test path</summary>

```
JBPY_JITC_QUICKLOOK_DIR=/host_shared/JITC_QuickLook_NITF/Quick-Look-Set-v2023.11.30 pdm run make lint test 
ruff check
All checks passed!
ruff format --diff
8 files already formatted
mypy jbpy
Success: no issues found in 5 source files
pytest
=============================================================================================================================================================================== test session starts ================================================================================================================================================================================
platform linux -- Python 3.12.10, pytest-8.4.0, pluggy-1.6.0
rootdir: /home/vscuser/git/glweb/software/third-party/jbpy
configfile: pyproject.toml
collected 106 items                                                                                                                                                                                                                                                                                                                                                                

test/test_core.py .......................                                                                                                                                                                                                                                                                                                                                    [ 21%]
test/test_jbpy.py ..................................................................................                                                                                                                                                                                                                                                                         [ 99%]
test/test_sectga.py .                                                                                                                                                                                                                                                                                                                                                        [100%]

=============================================================================================================================================================================== 106 passed in 2.12s ================================================================================================================================================================================

```

</details>