### PR TITLE
Bugfix: prevent empty DESSHF when DESSHL=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Only add `DESSHF` to `DataExtensionSubheader` when `DESSHL` is nonzero
+
+
+## [0.2.0] - 2025-08-26
+
+### Added
+- Support for Text and Graphic subheaders
+- `SubFile` class and `as_filelike` method to improve compatibility with other libraries
+- `jbpdump` utility for pulling the content out of segments
+- `jbpinfo` now supports formatting the output as JSON
+- CLI utilities now use `smart_open` if it is installed
+
+### Fixed
+- Handling for broken pipes when output of CLI utility is piped to another command
+
+
+## [0.1.0] - 2025-05-26
+
+### Added
+- Basic JBP functionality copied from SARkit's `_nitf_io.py`
+
+[unreleased]: https://github.com/ValkyrieSystems/jbpy/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ValkyrieSystems/jbpy/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/ValkyrieSystems/jbpy/releases/tag/v0.1.0

--- a/jbpy/core.py
+++ b/jbpy/core.py
@@ -2676,7 +2676,10 @@ class DataExtensionSubheader(Group):
 
     def _desshl_handler(self, field: Field) -> None:
         self._remove_all("DESSHF")
-        self._insert_after(field, DESSHF_Factory(self["DESID"], self["DESVER"], field))
+        if field.value > 0:
+            self._insert_after(
+                field, DESSHF_Factory(self["DESID"], self["DESVER"], field)
+            )
 
 
 class DataExtensionSegment(Group):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dev = [
 
 [project.urls]
 Repository = "https://github.com/ValkyrieSystems/jbpy"
+"Bug Tracker" = "https://github.com/ValkyrieSystems/jbpy/issues"
+Changelog = "https://github.com/ValkyrieSystems/jbpy/blob/main/CHANGELOG.md"
 
 [project.scripts]
 jbpinfo = "jbpy._jbpinfo:main"

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -369,6 +369,8 @@ def test_deseg():
     subheader["DESVER"].value = 1
     subheader["DESCLAS"].value = "U"
     assert "DESSHF" not in subheader
+    subheader["DESSHL"].value = 0
+    assert "DESSHF" not in subheader
     subheader["DESSHL"].value = 10
     assert subheader["DESSHF"].size == 10
     subheader["DESSHF"].value = "abcd"
@@ -381,8 +383,7 @@ def test_deseg():
     subheader["DESVER"].value = 1
 
     subheader["DESSHL"].value = 0
-    assert isinstance(subheader["DESSHF"], jbpy.core.XmlDataContentSubheader)
-    assert len(subheader["DESSHF"]) == 0
+    assert "DESSHF" not in subheader
 
     with pytest.raises(ValueError):
         subheader["DESSHL"].value = 1  # must exactly match a length of fields


### PR DESCRIPTION
# Description
This PR:
- adds a `CHANGELOG.md`  ala SARkit/SARPy
- fixes an apparent bug where an empty `DESSHF` was being added to `DataExtensionSubheader` when `DESSHL` was set to 0

  - this is different than the majority (all?) of the other conditional field handling in jbpy
  - from JBP2025.1: <img width="612" height="99" alt="image" src="https://github.com/user-attachments/assets/f58beeff-cd93-424b-8d73-3e6866c924c9" />