### PR TITLE
Bugfix: SubFile.seek for unsignedinteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `SubFile.seek` for some integer-like scalar types (e.g. `numpy.unsignedinteger`)
+
 
 ## [0.6.0] - 2026-02-03
 

--- a/jbpy/core.py
+++ b/jbpy/core.py
@@ -61,8 +61,8 @@ class SubFile:
 
     def __init__(self, file: Any, start: int, length: int):
         self._file = file
-        self._start = start
-        self._length = length
+        self._start = int(start)
+        self._length = int(length)
         self._pos = 0  # position within the subfile
 
     def seek(self, offset: int, whence: int = 0) -> int:
@@ -82,11 +82,11 @@ class SubFile:
             Current offset in the SubFile
         """
         if whence == 0:
-            new_pos = offset
+            new_pos = int(offset)
         elif whence == 1:
-            new_pos = self._pos + offset
+            new_pos = self._pos + int(offset)
         elif whence == 2:
-            new_pos = self._length + offset
+            new_pos = self._length + int(offset)
         else:
             raise ValueError(f"whence value {whence} unsupported")
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9,6 +9,7 @@ import random
 import string
 import tempfile
 
+import numpy as np
 import pytest
 
 import jbpy.core
@@ -783,6 +784,11 @@ def test_subfile(tmp_path):
         assert subfile.tell() == expected_pos
         subfile.seek(length + 100)
         assert subfile.read() == b""
+
+        # seeking works with int-like
+        subfile.seek(np.uint8(24), os.SEEK_SET)
+        subfile.seek(-8, os.SEEK_CUR)
+        assert subfile.tell() == 16
 
         assert subfile.readable()
 


### PR DESCRIPTION
# Description
@bombaci-vsc  found some unintuitive behavior with `SubFile.seek` when used with numpy scalar types. An example can be seen running the new test in `main`:

```
            # seeking works with  int-like
            subfile.seek(np.uint8(24), os.SEEK_SET)
>           subfile.seek(-8, os.SEEK_CUR)

test/test_core.py:790: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <jbpy.core.SubFile object at 0x7f9947be7620>, offset = -8, whence = 1

    def seek(self, offset: int, whence: int = 0) -> int:
        """
        Seek to a position within the subfile.
    
        Parameters
        ----------
        offset : int
            Offset to seek
        whence : int
            0 (start), 1 (current), or 2 (end of subfile)
    
        Returns
        -------
        int
            Current offset in the SubFile
        """
        if whence == 0:
            new_pos = offset
        elif whence == 1:
>           new_pos = self._pos + offset
                      ^^^^^^^^^^^^^^^^^^
E           OverflowError: Python integer -8 out of bounds for uint8

jbpy/core.py:87: OverflowError
==================================================================================================================================================================== short test summary info =====================================================================================================================================================================
FAILED test/test_core.py::test_subfile - OverflowError: Python integer -8 out of bounds for uint8
======================================================================================================================================================================= 1 failed in 0.73s ========================================================================================================================================================================
                                                                                                                                                                                                                                                                                                                                                                  
```

Wrapping a few things in `int` seems like a reasonable remedy.